### PR TITLE
Ensure that springs reach their goals

### DIFF
--- a/src/Animation/SpringScheduler.lua
+++ b/src/Animation/SpringScheduler.lua
@@ -80,6 +80,8 @@ local function updateAllSprings()
 
 	for spring in pairs(springsToSleep) do
 		activeSprings[spring] = nil
+		-- Guarantee that springs reach exact goals, since mathematically they only approach it infinitely
+		spring._currentValue = packType(spring._springGoals, spring._currentType)
 	end
 end
 


### PR DESCRIPTION
Mathematically, springs only approach their goals infinitely. In order for Fusion animation to be a reliable tool, it needs to ensure that goals are actually reached.

When a spring is marked as completed/sleeping (via epsilon threshold), we simply set the value to the goal. This guarantees that it will eventually be the exact goal value.