### PR TITLE
Fix ForValues producing no values

### DIFF
--- a/src/State/ForValues.lua
+++ b/src/State/ForValues.lua
@@ -123,7 +123,7 @@ function class:update(): boolean
 			table.clear(valueData.dependencySet)
 
 			local use = makeUseCallback(valueData.dependencySet)
-			local processOK, err, newOutValue, newMetaValue = xpcall(self._processor, parseError, use, inValue)
+			local processOK, newOutValue, newMetaValue = xpcall(self._processor, parseError, use, inValue)
 
 			if processOK then
 				if self._destructor == nil and (needsDestruction(newOutValue) or needsDestruction(newMetaValue)) then
@@ -145,7 +145,7 @@ function class:update(): boolean
 			else
 				-- restore old dependencies, because the new dependencies may be corrupt
 				valueData.oldDependencySet, valueData.dependencySet = valueData.dependencySet, valueData.oldDependencySet
-				logErrorNonFatal("forValuesProcessorError", err)
+				logErrorNonFatal("forValuesProcessorError", newOutValue)
 			end
 		end
 


### PR DESCRIPTION
xpcall does not return an error separate from a result. If xpcall succeeds, its result will start at the second return.