### PR TITLE
Fix failing defaultProps test.

### DIFF
--- a/src/Instances/defaultProps.lua
+++ b/src/Instances/defaultProps.lua
@@ -147,7 +147,7 @@ return {
 	
 	TrussPart = {
 		Anchored = true,
-		Size = Vector3.one,
+		Size = Vector3.one * 2,
 		FrontSurface = Enum.SurfaceType.Smooth,
 		BackSurface = Enum.SurfaceType.Smooth,
 		LeftSurface = Enum.SurfaceType.Smooth,


### PR DESCRIPTION
Setting the Size of a TrussPart to (1,1,1) constrains to its minimum Size of (2,2,2). Because these values are different, the test for default properties fails.

Fixed by setting the default Size of TrussPart to (2,2,2) instead of (1,1,1).