### PR TITLE
Make NaN similar to itself

### DIFF
--- a/src/Utility/isSimilar.lua
+++ b/src/Utility/isSimilar.lua
@@ -10,7 +10,8 @@ local function isSimilar(a: any, b: any): boolean
     if typeof(a) == "table" then
         return false
     else
-        return a == b
+        -- NaN does not equal itself but is the same
+        return a == b or a ~= a and b ~= b
     end
 end
 


### PR DESCRIPTION
In Lua, NaN does not equal itself (IEEE 754). However, it is the same value. Make NaN similar to itself in [`isSimilar.lua`](https://github.com/dphfox/Fusion/blob/ce5ba5fef510ac65c76cfa22a02a3681746a9501/src/Utility/isSimilar.lua) to avoid unnecessary recomputations for NaN values.