### PR TITLE
Parent children in batchable order when possible

### DIFF
--- a/src/Instances/Children.lua
+++ b/src/Instances/Children.lua
@@ -98,6 +98,11 @@ function Children:apply(propValue: any, applyTo: Instance, cleanupTasks: {PubTyp
 				else
 					-- previously here; we want to reuse, so remove from old
 					-- set so we don't encounter it during unparenting
+
+					-- note: children that are added dynamically at a later time will not
+					-- be batched with these pre-existing children since that would require all
+					-- children to be re-parented in batching order, which is more expensive
+					-- than just sacrificing some potential batching
 					oldParented[child] = nil
 				end
 

--- a/src/Instances/Children.lua
+++ b/src/Instances/Children.lua
@@ -18,9 +18,9 @@ type Set<T> = {[T]: boolean}
 -- Experimental flag: name children based on the key used in the [Children] table
 local EXPERIMENTAL_AUTO_NAMING = false
 
-local function batchingSortedInsert(t: {Instance}, instance: Instance)
+local function batchingSortedInsert(queue: {Instance}, instance: Instance)
 	--  initialise binary search values
-	local iStart, iEnd, iMid, iState = 1, #t, 1, 0
+	local iStart, iEnd, iMid, iState = 1, #queue, 1, 0
 	-- store instance info to avoid having to index the properties multiple times
 	local className = instance.ClassName
 	local isImage = className == "ImageLabel" or className == "ImageButton"
@@ -29,7 +29,7 @@ local function batchingSortedInsert(t: {Instance}, instance: Instance)
 	while iStart <= iEnd do
 		-- calculate middle
 		iMid = math.floor((iStart + iEnd) / 2)
-		local midInstance = t[iMid]
+		local midInstance = queue[iMid]
 		local midClassName = midInstance.ClassName
 		-- compare
 		if className < midClassName then
@@ -48,7 +48,7 @@ local function batchingSortedInsert(t: {Instance}, instance: Instance)
 		end
 	end
 	-- insert
-	table.insert(t, iMid + iState, instance)
+	table.insert(queue, iMid + iState, instance)
 end
 
 local Children = {}


### PR DESCRIPTION
Closes #293.

Modifies `Fusion.Children`'s parenting behavior to parent things in a way that works for Roblox's naive greedy drawcall batching whenever reasonably possible. Contains comments for additional context where needed.