### PR TITLE
Let Computeds release values heuristically

### DIFF
--- a/src/State/Computed.lua
+++ b/src/State/Computed.lua
@@ -7,6 +7,7 @@
 
 local Package = script.Parent.Parent
 local Types = require(Package.Types)
+local External = require(Package.External)
 -- Logging
 local logError = require(Package.Logging.logError)
 local logErrorNonFatal = require(Package.Logging.logErrorNonFatal)
@@ -20,8 +21,8 @@ local makeUseCallback = require(Package.State.makeUseCallback)
 
 local class = {}
 
-local CLASS_METATABLE = {__index = class}
-local WEAK_KEYS_METATABLE = {__mode = "k"}
+local CLASS_METATABLE = { __index = class }
+local WEAK_KEYS_METATABLE = { __mode = "k" }
 
 --[[
 	Recalculates this Computed's cached value and dependencies.
@@ -58,10 +59,39 @@ function class:update(): boolean
 			self._destructor(oldValue)
 		end
 		self._value = newValue
+		self._releasedValue = false
 
 		-- add this object to the dependencies' dependent sets
 		for dependency in pairs(self.dependencySet) do
 			dependency.dependentSet[self] = true
+		end
+
+		if self._destructor == nil then
+			-- for primitive values, we can avoid storing the value indefinitely
+			-- in some cases
+			External.doTaskDeferred(function()
+				if next(self.dependentSet) == nil then
+					-- we don't know enough about the dependents to know if
+					-- we can release the value
+					return
+				end
+
+				for dependent in self.dependentSet do
+					if dependent.kind ~= "Observer" then
+						return
+					end
+				end
+
+				-- if there are only observer dependents, then we don't need to store the value indefinitely
+				External.doTaskDeferred(function()
+					if self._releasedValue or self._value ~= newValue then
+						-- the value was updated or released while we deferred
+						return
+					end
+					self._releasedValue = true
+					self._value = nil
+				end)
+			end)
 		end
 
 		return not similar
@@ -86,6 +116,10 @@ end
 	Returns the interior value of this state object.
 ]]
 function class:_peek(): any
+	if self._releasedValue then
+		-- The value was released, so we need to recalculate it.
+		self:update()
+	end
 	return self._value
 end
 
@@ -105,7 +139,7 @@ local function Computed<T>(processor: () -> T, destructor: ((T) -> ())?): Types.
 		_oldDependencySet = {},
 		_processor = processor,
 		_destructor = destructor,
-		_value = nil
+		_value = nil,
 	}, CLASS_METATABLE)
 
 	self:update()


### PR DESCRIPTION
Implements #305 for Computeds.

When used in Lua Learning, I went from thousands of UDim2 values being held to just a couple hundred. Same for UDim, Vector2, etc.