### PR TITLE
Fix to ensure springs propogate their final state before they sleep

### DIFF
--- a/src/Animation/SpringScheduler.lua
+++ b/src/Animation/SpringScheduler.lua
@@ -73,15 +73,16 @@ local function updateAllSprings(
 		end
 	end
 
-	for spring in pairs(activeSprings) do
-		spring._currentValue = packType(spring._springPositions, spring._currentType)
-		updateAll(spring)
-	end
-
 	for spring in pairs(springsToSleep) do
 		activeSprings[spring] = nil
 		-- Guarantee that springs reach exact goals, since mathematically they only approach it infinitely
 		spring._currentValue = packType(spring._springGoals, spring._currentType)
+		updateAll(spring)
+	end
+
+	for spring in pairs(activeSprings) do
+		spring._currentValue = packType(spring._springPositions, spring._currentType)
+		updateAll(spring)
 	end
 end
 


### PR DESCRIPTION
Currently Springs internally have their proper value, but they sometimes dont send out the value they have before they sleep, resulting in a disconnect.

This change just ensures that the final value is properly propogated out before sleeping the spring.