### PR TITLE
Add luaurc for syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.luau linguist-language=Lua

--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,3 @@
+{
+	"languageMode": "strict"
+}


### PR DESCRIPTION
The PR aims to add syntax highlighting for luau files (temporarily) until syntax highlighting support for files with `.luau` extension is added.