### PR TITLE
Fixed an old link & path to use .luau

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -116,7 +116,7 @@ Studio, then you can use Fusion's source code directly.
 	local Fusion = require("../shared/Fusion")
 
 	-- vanilla Luau
-	local Fusion = require("../shared/Fusion/init.lua")
+	local Fusion = require("../shared/Fusion/init.luau")
 	```
 
 -----

--- a/docs/tutorials/roblox/new-instances.md
+++ b/docs/tutorials/roblox/new-instances.md
@@ -64,4 +64,4 @@ turned off and default content is removed.
 ![Showing the difference between a text label made with Instance.new and Fusion's New function.](Default-Props-Dark.svg#only-dark)
 ![Showing the difference between a text label made with Instance.new and Fusion's New function.](Default-Props-Light.svg#only-light)
 
-For a complete list, [take a look at Fusion's default properties file.](https://github.com/Elttob/Fusion/blob/main/src/Instances/defaultProps.lua)
+For a complete list, [take a look at Fusion's default properties file.](https://github.com/Elttob/Fusion/blob/main/src/Instances/defaultProps.luau)


### PR DESCRIPTION
I noticed the default props link on the docs is broken. I searched for all `.lua` references (only two) and fixed them.
Resolves #330 