### PR TITLE
Change `Fusion.doCleanup` to no longer be variadic

### DIFF
--- a/docs/api-reference/memory/members/docleanup.md
+++ b/docs/api-reference/memory/members/docleanup.md
@@ -14,7 +14,7 @@
 
 ```Lua
 function Fusion.doCleanup(
-	...: unknown
+	task: unknown
 ): ()
 ```
 
@@ -30,7 +30,7 @@ Attempts to destroy all arguments based on their runtime type.
 ## Parameters
 
 <h3 markdown>
-	...
+	task
 	<span class="fusiondoc-api-type">
 		: unknown
 	</span>

--- a/src/Memory/doCleanup.luau
+++ b/src/Memory/doCleanup.luau
@@ -14,7 +14,7 @@ local task = nil -- Disable usage of Roblox's task scheduler
 	- an array - `cleanup` will be called on each item
 ]]
 
-local function doCleanupOne(
+local function doCleanup(
 	task: unknown
 )
 	local taskType = typeof(task)
@@ -53,18 +53,10 @@ local function doCleanupOne(
 			-- It is important to iterate backwards through the table, since
 			-- objects are added in order of construction.
 			for index = #task, 1, -1 do
-				doCleanupOne(task[index])
+				doCleanup(task[index])
 				task[index] = nil
 			end
 		end
-	end
-end
-
-local function doCleanup(
-	...: unknown
-)
-	for index = 1, select("#", ...) do
-		doCleanupOne(select(index, ...))
 	end
 end
 

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -245,7 +245,7 @@ export type Fusion = {
 	version: Version,
 	Contextual: ContextualConstructor,
 
-	doCleanup: (...unknown) -> (),
+	doCleanup: (unknown) -> (),
 	scoped: ScopedConstructor,
 	deriveScope: <T>(existing: Scope<T>) -> Scope<T>,
 

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -271,7 +271,6 @@ export type Fusion = {
 	Attribute: (attributeName: string) -> SpecialKey,
 	AttributeChange: (attributeName: string) -> SpecialKey,
 	AttributeOut: (attributeName: string) -> SpecialKey,
-	
 }
 
 return nil

--- a/test/Spec/Memory/doCleanup.spec.luau
+++ b/test/Spec/Memory/doCleanup.spec.luau
@@ -132,18 +132,4 @@ return function()
 		expect(runs[2]).to.equal(2)
 		expect(runs[3]).to.equal(1)
 	end)
-
-	it("should clean up variadic arguments", function()
-		local expect = getfenv().expect
-		
-		local numRuns = 0
-
-		local function doRun()
-			numRuns += 1
-		end
-
-		doCleanup(doRun, doRun, doRun)
-
-		expect(numRuns).to.equal(3)
-	end)
 end


### PR DESCRIPTION
There is no need for ``Fusion.doCleanup`` to accept variadic arguments anymore, as one could simply pass in a table (scope) anyways.

```lua
Fusion.doCleanup(a, b, c)
```

Can now be expressed as:

```lua
Fusion.doCleanup({a, b, c})
```

This makes the implementation and especially the typing of ``Fusion.doCleanup`` much simpler.