### PR TITLE
Convert `doCleanup` to use the `Task` type

### DIFF
--- a/docs/api-reference/memory/members/docleanup.md
+++ b/docs/api-reference/memory/members/docleanup.md
@@ -14,7 +14,7 @@
 
 ```Lua
 function Fusion.doCleanup(
-	task: unknown
+	task: Fusion.Task
 ): ()
 ```
 
@@ -32,7 +32,7 @@ Attempts to destroy all arguments based on their runtime type.
 <h3 markdown>
 	task
 	<span class="fusiondoc-api-type">
-		: unknown
+		: <a href="../../../memory/types/task">Task</a>
 	</span>
 </h3>
 

--- a/src/Memory/doCleanup.luau
+++ b/src/Memory/doCleanup.luau
@@ -13,29 +13,26 @@ local task = nil -- Disable usage of Roblox's task scheduler
 	- a table with a `Destroy` or `destroy` function - will be called
 	- an array - `cleanup` will be called on each item
 ]]
+local Package = script.Parent.Parent
+local Types = require(Package.Types)
 
 local function doCleanup(
-	task: unknown
+	task: Types.Task
 )
-	local taskType = typeof(task)
-
 	-- case 1: Instance
-	if taskType == "Instance" then
-		local task = task :: Instance
+	if typeof(task) == "Instance" then
 		task:Destroy()
 
 	-- case 2: RBXScriptConnection
-	elseif taskType == "RBXScriptConnection" then
-		local task = task :: RBXScriptConnection
+	elseif typeof(task) == "RBXScriptConnection" then
 		task:Disconnect()
 
 	-- case 3: callback
-	elseif taskType == "function" then
-		local task = task :: (...unknown) -> (...unknown)
+	elseif typeof(task) == "function" then
 		task()
 
-	elseif taskType == "table" then
-		local task = task :: {destroy: unknown?, Destroy: unknown?}
+	elseif typeof(task) == "table" then
+		local task = (task :: any) :: {Destroy: (...unknown) -> (...unknown)?, destroy: (...unknown) -> (...unknown)?}
 
 		-- case 4: destroy() function
 		if typeof(task.destroy) == "function" then
@@ -49,7 +46,7 @@ local function doCleanup(
 
 		-- case 6: array of tasks
 		elseif task[1] ~= nil then
-			local task = task :: {unknown}
+			local task = task :: {Types.Task}
 			-- It is important to iterate backwards through the table, since
 			-- objects are added in order of construction.
 			for index = #task, 1, -1 do

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -42,7 +42,7 @@ export type Task =
 	{Task}
 
 -- A scope of tasks to clean up.
-export type Scope<Constructors> = {unknown} & Constructors
+export type Scope<Constructors> = {Task} & Constructors
 
 -- An object which uses a scope to dictate how long it lives.
 export type ScopedObject = {
@@ -245,7 +245,7 @@ export type Fusion = {
 	version: Version,
 	Contextual: ContextualConstructor,
 
-	doCleanup: (unknown) -> (),
+	doCleanup: (Task) -> (),
 	scoped: ScopedConstructor,
 	deriveScope: <T>(existing: Scope<T>) -> Scope<T>,
 


### PR DESCRIPTION
This converts ``Fusion.doCleanup`` to use the more refined ``Task`` type that Fusion provides.