### PR TITLE
Add innerScope to the Fusion type

### DIFF
--- a/src/Types.luau
+++ b/src/Types.luau
@@ -239,7 +239,8 @@ export type Fusion = {
 
 	doCleanup: (Task) -> (),
 	scoped: ScopedConstructor,
-	deriveScope: <T>(existing: Scope<T>) -> Scope<T>,
+	deriveScope: <T>(existing: Scope<T>, methods: {[unknown]: unknown}?, ...{[unknown]: unknown}) -> Scope<T>,
+	innerScope: <T>(existing: Scope<T>, ...{[unknown]: unknown}) -> Scope<T>,
 
 	peek: Use,
 	Value: ValueConstructor,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -239,8 +239,8 @@ export type Fusion = {
 
 	doCleanup: (Task) -> (),
 	scoped: ScopedConstructor,
-	deriveScope: <T>(existing: Scope<T>, methods: {[unknown]: unknown}?, ...{[unknown]: unknown}) -> Scope<T>,
-	innerScope: <T>(existing: Scope<T>, ...{[unknown]: unknown}) -> Scope<T>,
+	deriveScope: <T>(existing: Scope<T>) -> Scope<T>,
+	innerScope: <T>(existing: Scope<T>) -> Scope<T>,
 
 	peek: Use,
 	Value: ValueConstructor,


### PR DESCRIPTION
Adds innerScope as a type to the Fusion type to avoid pesky type errors.