### PR TITLE
Remove redundant properties from Best Practices/Components

### DIFF
--- a/docs/tutorials/best-practices/components.md
+++ b/docs/tutorials/best-practices/components.md
@@ -263,11 +263,9 @@ Here's an example of how you could split up some components into modules:
             
             [Children] = {
                 scope:Message {
-					Scope = scope,
                     Text = props.Message
                 }
                 scope:Button {
-					Scope = scope,
                     Text = props.DismissText
                 }
             }


### PR DESCRIPTION
Remove redundant property `Scope` from methods called from the inner scope.
The **Message** and **Button** do not request `Scope` in their properties, and since `scope` was overwrote with the inner scope, these are passing the same thing. The inner scope is already being passed in the object orientation.

This functions fine.

```lua
scope = scope:innerScope({ ...inner })
scope.Button(scope, { ...props })
```

This is what it currently is, which doesn't work as **Button** does not have a field called `Scope`.

```lua
scope = scope:innerScope({ ...inner })
scope.Button(scope, { Scope = scope, ...props })
```