### PR TITLE
Fix merge not overwriting values

### DIFF
--- a/src/Utility/merge.luau
+++ b/src/Utility/merge.luau
@@ -24,6 +24,8 @@ local function merge(
 				into[key] = value
 			elseif overwrite == "none" then
 				External.logError("mergeConflict", nil, tostring(key))
+			else
+				into[key] = value
 			end
 		end
 		return merge(if overwrite == "first" then "none" else overwrite, into, ...)

--- a/src/Utility/merge.luau
+++ b/src/Utility/merge.luau
@@ -20,9 +20,7 @@ local function merge(
 		return into
 	else
 		for key, value in from do
-			if into[key] == nil then
-				into[key] = value
-			elseif overwrite == "none" then
+			if into[key] == nil and overwrite == "none" then
 				External.logError("mergeConflict", nil, tostring(key))
 			else
 				into[key] = value

--- a/src/Utility/merge.luau
+++ b/src/Utility/merge.luau
@@ -20,7 +20,7 @@ local function merge(
 		return into
 	else
 		for key, value in from do
-			if into[key] == nil and overwrite == "none" then
+			if into[key] ~= nil and overwrite == "none" then
 				External.logError("mergeConflict", nil, tostring(key))
 			else
 				into[key] = value


### PR DESCRIPTION
The `merge` function does not actually overwrite any values when `overwrite` is not set to `"none"`.

If you call `innerScope` with a table containing an existing property on the scope, it will not overwrite that property.

```lua
local scope = Fusion.scoped({ a = 5 })
local newScope = Fusion.innerScope(scope, { a = 6 })

print(newScope.a) -- 5
```