### PR TITLE
Change deriveScope and innerScope to use DeriveScopeConstructor

### DIFF
--- a/src/Types.luau
+++ b/src/Types.luau
@@ -239,8 +239,8 @@ export type Fusion = {
 
 	doCleanup: (Task) -> (),
 	scoped: ScopedConstructor,
-	deriveScope: <T>(existing: Scope<T>) -> Scope<T>,
-	innerScope: <T>(existing: Scope<T>) -> Scope<T>,
+	deriveScope: DeriveScopeConstructor,
+	innerScope: DeriveScopeConstructor,
 
 	peek: Use,
 	Value: ValueConstructor,


### PR DESCRIPTION
This allows for accurate typing, as you're currently unable to add additional tables in innerScope and deriveScope.