### PR TITLE
Allow automatic wrapping of functions in springs

### DIFF
--- a/src/Animation/Spring.luau
+++ b/src/Animation/Spring.luau
@@ -18,6 +18,7 @@ local updateAll = require(Package.State.updateAll)
 local isState = require(Package.State.isState)
 local peek = require(Package.State.peek)
 local whichLivesLonger = require(Package.Memory.whichLivesLonger)
+local Computed = require(Package.State.Computed)
 
 local class = {}
 class.type = "State"
@@ -177,13 +178,19 @@ end
 
 local function Spring<T>(
 	scope: Types.Scope<unknown>,
-	goal: Types.UsedAs<T>,
+	goal: Types.UsedAs<T> | (use: Types.Use) -> T,
 	speed: Types.UsedAs<number>?,
 	damping: Types.UsedAs<number>?
 ): Types.Spring<T>
 	if typeof(scope) ~= "table" or isState(scope) then
 		External.logError("scopeMissing", nil, "Springs", "myScope:Spring(goalState, speed, damping)")
 	end
+
+	-- Wrap goal in a Computed if it is a function
+	if typeof(goal) == "function" then
+		goal = Computed(goal)
+	end
+
 	-- apply defaults for speed and damping
 	if speed == nil then
 		speed = 10


### PR DESCRIPTION
This change allows for functions to be given directly to Springs so that you don't have to constantly wrap them in Computeds.
Forced Old Method:
```lua
Spring(Computed(function(use)
   return if use(x) then 0 else 1
end))
```
New Optional Method:
```lua
Spring(function(use)
   return if use(x) then 0 else 1
end)
```
This would help reduce code bloat, allow for easier reading, and bring it in line with other state object usage. It should be entirely backwards compatible.