### PR TITLE
Add `Child` helper function

### DIFF
--- a/docs/api-reference/roblox/members/attribute.md
+++ b/docs/api-reference/roblox/members/attribute.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>Attribute</span>
 </nav>

--- a/docs/api-reference/roblox/members/attributechange.md
+++ b/docs/api-reference/roblox/members/attributechange.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>AttributeChange</span>
 </nav>

--- a/docs/api-reference/roblox/members/attributeout.md
+++ b/docs/api-reference/roblox/members/attributeout.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>AttributeOut</span>
 </nav>

--- a/docs/api-reference/roblox/members/child.md
+++ b/docs/api-reference/roblox/members/child.md
@@ -1,0 +1,54 @@
+<nav class="fusiondoc-api-breadcrumbs">
+	<span>Roblox</span>
+	<span>Members</span>
+	<span>Child</span>
+</nav>
+
+<h1 class="fusiondoc-api-header" markdown>
+	<span class="fusiondoc-api-icon" markdown>:octicons-workflow-24:</span>
+	<span class="fusiondoc-api-name">Child</span>
+	<span class="fusiondoc-api-type">
+		-> <a href="../../types/child">Child</a>
+	</span>
+</h1>
+
+```Lua
+function Fusion.Child(
+	child: Child
+): Child
+```
+
+Returns the [child](../../types/child) passed into it.
+
+This function does no processing. It only serves as a hint to the Luau type
+system, constraining the type of the argument.
+
+-----
+
+## Parameters
+
+<h3 markdown>
+	child
+	<span class="fusiondoc-api-type">
+		: <a href="../../types/child">Child</a>
+	</span>
+</h3>
+
+The argument whose type should be constrained.
+
+-----
+
+<h2 markdown>
+	Returns
+	<span class="fusiondoc-api-type">
+		-> <a href="../../types/child">Child</a>
+	</span>
+</h2>
+
+The argument with the newly cast static type.
+
+-----
+
+## Learn More
+
+- [Parenting tutorial](../../../../tutorials/roblox/parenting)

--- a/docs/api-reference/roblox/members/children.md
+++ b/docs/api-reference/roblox/members/children.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>Children</span>
 </nav>

--- a/docs/api-reference/roblox/members/hydrate.md
+++ b/docs/api-reference/roblox/members/hydrate.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>Hydrate</span>
 </nav>

--- a/docs/api-reference/roblox/members/new.md
+++ b/docs/api-reference/roblox/members/new.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>New</span>
 </nav>

--- a/docs/api-reference/roblox/members/onchange.md
+++ b/docs/api-reference/roblox/members/onchange.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>OnChange</span>
 </nav>

--- a/docs/api-reference/roblox/members/onevent.md
+++ b/docs/api-reference/roblox/members/onevent.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>OnEvent</span>
 </nav>

--- a/docs/api-reference/roblox/members/out.md
+++ b/docs/api-reference/roblox/members/out.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>Out</span>
 </nav>

--- a/docs/api-reference/roblox/members/ref.md
+++ b/docs/api-reference/roblox/members/ref.md
@@ -1,5 +1,5 @@
 <nav class="fusiondoc-api-breadcrumbs">
-	<span>Memory</span>
+	<span>Roblox</span>
 	<span>Members</span>
 	<span>Ref</span>
 </nav>

--- a/docs/tutorials/roblox/parenting.md
+++ b/docs/tutorials/roblox/parenting.md
@@ -129,3 +129,36 @@ local folder = scope:New "Folder" {
     }
 }
 ```
+!!! tip
+
+	If you're using strictly typed Luau, you might incorrectly see type errors
+	when mixing different kinds of value in arrays. This commonly causes
+	problems when listing out children.
+
+	If you're seeing type errors, try importing the
+	[`Child` function](../../../api-reference/roblox/members/child)
+	and using it when listing out children:
+
+	```Lua hl_lines="1 6"
+	local Child = Fusion.Child
+
+	-- ... later ...
+
+	local folder = scope:New "Folder" {
+		[Children] = Child {
+			scope:New "Part" {
+				Name = "Gregory",
+				Color = Color3.new(1, 0, 0)
+			},
+			scope:Computed(function(use)
+				return if use(includeModel)
+					then modelChildren:GetChildren() -- array of children
+					else nil
+			end)
+		}
+	}
+	```
+
+	The `Child` function doesn't do any processing, but instead encourages the
+	Luau type system to infer a more useful type and avoid the problem.
+

--- a/src/Instances/Child.luau
+++ b/src/Instances/Child.luau
@@ -1,0 +1,21 @@
+--!strict
+--!nolint LocalUnused
+--!nolint LocalShadow
+local task = nil -- Disable usage of Roblox's task scheduler
+
+--[[
+	Helper function for type checking purposes. Casts the input to a `Child`
+	type, while constraining the input to be an array of `Child` - this prevents
+	Luau from erroneously inferring a different array type for the input.
+]]
+
+local Package = script.Parent.Parent
+local Types = require(Package.Types)
+
+local function Child(
+	x: {Types.Child}
+): Types.Child
+	return x
+end
+
+return Child

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -257,6 +257,7 @@ export type Fusion = {
 	Hydrate: HydrateConstructor,
 
 	Ref: SpecialKey,
+	Child: ({Child}) -> Child,
 	Children: SpecialKey,
 	Out: (propertyName: string) -> SpecialKey,
 	OnEvent: (eventName: string) -> SpecialKey,

--- a/src/init.luau
+++ b/src/init.luau
@@ -63,6 +63,7 @@ local Fusion: Types.Fusion = table.freeze {
 	Attribute = require(script.Instances.Attribute),
 	AttributeChange = require(script.Instances.AttributeChange),
 	AttributeOut = require(script.Instances.AttributeOut),
+	Child = require(script.Instances.Child),
 	Children = require(script.Instances.Children),
 	Hydrate = require(script.Instances.Hydrate),
 	New = require(script.Instances.New),


### PR DESCRIPTION
Closes #349.

- [x] Implement `Child` function
- [x] Add `Child` function to Fusion type
- [x] Document `Child` function
- [x] Update examples to use `Child` function