### PR TITLE
Force evaluations when depending on GraphObjects

### DIFF
--- a/src/Graph/depend.luau
+++ b/src/Graph/depend.luau
@@ -17,11 +17,12 @@ local function depend<T>(
 	dependent: Types.GraphObject,
 	dependency: Types.GraphObject
 ): ()
-	if dependency.lastChange == nil then
-		-- Newly created objects might not have any transitive dependencies
-		-- captured yet, so ensure that they're present.
-		evaluate(dependency, true)
-	end
+	-- Ensure dependencies are evaluated and up-to-date
+	-- when they are depended on. Also, ewly created objects
+	-- might not have any transitive dependencies captured yet,
+	-- so ensure that they're present.
+	evaluate(dependency, false)
+
 	if table.isfrozen(dependent.dependencySet) or table.isfrozen(dependency.dependentSet) then
 		External.logError("cannotDepend", nil, nameOf(dependent, "Dependent"), nameOf(dependency, "dependency"))
 	end

--- a/src/Graph/depend.luau
+++ b/src/Graph/depend.luau
@@ -18,7 +18,7 @@ local function depend<T>(
 	dependency: Types.GraphObject
 ): ()
 	-- Ensure dependencies are evaluated and up-to-date
-	-- when they are depended on. Also, ewly created objects
+	-- when they are depended on. Also, newly created objects
 	-- might not have any transitive dependencies captured yet,
 	-- so ensure that they're present.
 	evaluate(dependency, false)


### PR DESCRIPTION
This change ensures that GraphObjects are evaluated when they are depended on. The biggest difference is that eager GraphObjects now force evaluations on lazy dependencies and ensure they are actually updated _eagerly_. Previously eager GraphObjects did not force evaluations, leading to issues where Observers did not update past their initial evaluation when watching a lazy GraphObject, especially since nothing was forcing the lazy GraphObject to update and get out of its invalid condition.