### PR TITLE
Make Tween and Spring eager

### DIFF
--- a/src/Animation/Spring.luau
+++ b/src/Animation/Spring.luau
@@ -53,7 +53,7 @@ type Self<T> = Types.Spring<T> & {
 local class = {}
 class.type = "State"
 class.kind = "Spring"
-class.timeliness = "lazy"
+class.timeliness = "eager"
 
 local METATABLE = table.freeze {__index = class}
 
@@ -94,7 +94,7 @@ local function Spring<T>(
 			_activeTargetP = {},
 			_activeType = "",
 			_damping = damping,
-			_EXTREMELY_DANGEROUS_usedAsValue = nil,
+			_EXTREMELY_DANGEROUS_usedAsValue = peek(goal),
 			_goal = goal,
 			_speed = speed,
 			_stopwatch = stopwatch
@@ -137,6 +137,10 @@ local function Spring<T>(
 		)
 		depend(self, dampingState)
 	end
+
+	-- Eagerly evaluated objects need to evaluate themselves so that they're
+	-- valid at all times.
+	evaluate(self, true)
 
 	return self
 end

--- a/src/Animation/Spring.luau
+++ b/src/Animation/Spring.luau
@@ -117,7 +117,6 @@ local function Spring<T>(
 			goalState.scope, goalState.oldestTask,
 			checkLifetime.formatters.animationGoal
 		)
-		depend(self, goalState)
 	end
 	local speedState = castToState(speed)
 	if speedState ~= nil then

--- a/src/Animation/Tween.luau
+++ b/src/Animation/Tween.luau
@@ -98,7 +98,6 @@ local function Tween<T>(
 			goalState.scope, goalState.oldestTask,
 			checkLifetime.formatters.animationGoal
 		)
-		depend(self, goalState)
 	end
 
 	local tweenInfoState = castToState(tweenInfo)

--- a/src/Animation/Tween.luau
+++ b/src/Animation/Tween.luau
@@ -17,6 +17,7 @@ local External = require(Package.External)
 local checkLifetime = require(Package.Memory.checkLifetime)
 -- Graph
 local depend = require(Package.Graph.depend)
+local evaluate = require(Package.Graph.evaluate)
 -- State
 local castToState = require(Package.State.castToState)
 local peek = require(Package.State.peek)
@@ -43,7 +44,7 @@ export type Self<T> = Types.Tween<T> & {
 local class = {}
 class.type = "State"
 class.kind = "Tween"
-class.timeliness = "lazy"
+class.timeliness = "eager"
 
 local METATABLE = table.freeze {__index = class}
 
@@ -74,7 +75,7 @@ local function Tween<T>(
 			_activeFrom = nil,
 			_activeTo = nil,
 			_activeTweenInfo = nil,
-			_EXTREMELY_DANGEROUS_usedAsValue = nil,
+			_EXTREMELY_DANGEROUS_usedAsValue = peek(goal),
 			_goal = goal,
 			_stopwatch = stopwatch,
 			_tweenInfo = tweenInfo or TweenInfo.new()
@@ -97,6 +98,7 @@ local function Tween<T>(
 			goalState.scope, goalState.oldestTask,
 			checkLifetime.formatters.animationGoal
 		)
+		depend(self, goalState)
 	end
 
 	local tweenInfoState = castToState(tweenInfo)
@@ -107,6 +109,10 @@ local function Tween<T>(
 			checkLifetime.formatters.parameter, "tween info"
 		)
 	end
+
+	-- Eagerly evaluated objects need to evaluate themselves so that they're
+	-- valid at all times.
+	evaluate(self, true)
 
 	return self
 end

--- a/src/Animation/getTweenRatio.luau
+++ b/src/Animation/getTweenRatio.luau
@@ -24,6 +24,11 @@ local function getTweenRatio(
 	if reverses then
 		cycleDuration += duration
 	end
+	-- If currentTime is infinity, then presumably the tween should be over.
+	-- This avoids NaN when the duration of an infinitely repeating tween is given.
+	if currentTime == math.huge then
+		return 1
+	end
 	if currentTime >= cycleDuration * numCycles and tweenInfo.RepeatCount > -1 then
 		return 1
 	end


### PR DESCRIPTION
Allows Tweens and Springs to begin their animations even when nothing eager depends on them. There is still another bug due to how External handles update steps, but I didn't include a fix as it would require a big enough change to warrant discussion.