### PR TITLE
Fix observer indirect dependencies bug

### DIFF
--- a/src/Graph/Observer.luau
+++ b/src/Graph/Observer.luau
@@ -105,7 +105,7 @@ function class._evaluate(
 	for _, callback in self._changeListeners do
 		External.doTaskImmediate(callback)
 	end
-	return false
+	return true
 end
 
 table.freeze(class)

--- a/src/Graph/change.luau
+++ b/src/Graph/change.luau
@@ -68,7 +68,7 @@ local function change(
 		end
 	end
 	for _, eagerTarget in eagerList do
-		evaluate(eagerTarget, true)
+		evaluate(eagerTarget, false)
 	end
 end
 


### PR DESCRIPTION
Fixes a bug in push-pull where observers will fire if an indirect dependency changes but the direct dependency doesn't.
```luau
local value = scope:Value(1)
local computed = scope:Computed(function(use, scope)
	return math.abs(use(value))
end)

local numFires = 0
scope:Observer(computed):onChange(function()
	numFires += 1
end)

value:set(-1)
value:set(1)
assert(numFires == 0)
```