### PR TITLE
Properly cache New invocations

### DIFF
--- a/src/Instances/New.luau
+++ b/src/Instances/New.luau
@@ -16,6 +16,12 @@ local applyInstanceProps = require(Package.Instances.applyInstanceProps)
 
 type Component = (Types.PropertyTable) -> Instance
 
+local scopeComponents: {
+	[Types.Scope<unknown>]: {
+		[string]: Component
+	}
+} = {}
+
 local function New(
 	scope: Types.Scope<unknown>,
 	className: string
@@ -25,29 +31,37 @@ local function New(
 		External.logError("scopeMissing", nil, "instances using New", "myScope:New \"" .. scope .. "\" { ... }")
 	end
 
-	-- This might look appealing to try and cache. But please don't. The scope
-	-- upvalue is shared between the two curried function calls, so this will
-	-- open incredible cross-codebase wormholes like you've never seen before.
-	return function(
-		props: Types.PropertyTable
-	): Instance
-		local ok, instance = pcall(Instance.new, className)
-		if not ok then
-			External.logError("cannotCreateClass", nil, className)
-		end
-
-		local classDefaults = defaultProps[className]
-		if classDefaults ~= nil then
-			for defaultProp, defaultValue in pairs(classDefaults) do
-				(instance :: any)[defaultProp] = defaultValue
-			end
-		end
-
-		table.insert(scope, instance)
-		applyInstanceProps(scope, props, instance)
-
-		return instance
+	local componentCache = scopeComponents[scope]
+	if not componentCache then
+		componentCache = {}
+		scopeComponents[scope] = componentCache
 	end
+
+	local component = componentCache[className]
+	if not component then
+		function component(
+			props: Types.PropertyTable
+		): Instance
+			local ok, instance = pcall(Instance.new, className)
+			if not ok then
+				External.logError("cannotCreateClass", nil, className)
+			end
+	
+			local classDefaults = defaultProps[className]
+			if classDefaults ~= nil then
+				for defaultProp, defaultValue in pairs(classDefaults) do
+					(instance :: any)[defaultProp] = defaultValue
+				end
+			end
+	
+			table.insert(scope, instance)
+			applyInstanceProps(scope, props, instance)
+	
+			return instance
+		end
+		componentCache[className] = component
+	end
+	return component
 end
 
 return New


### PR DESCRIPTION
Properly caches New invocations by caching all components under a table paired with its scope. Internally it caches invocations as follow:

```luau
local scopeComponents: {
	[Types.Scope<unknown>]: {
		[string]: Component
	}
} = {}
```

Contrast to the previous commit that attempted to cache New invocations, this PR solves the problem of scope upvalues being shared by also caching it.