### PR TITLE
Update default type of Scope exported by Fusion

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -9,6 +9,8 @@ local task = nil -- Disable usage of Roblox's task scheduler
 local Types = require(script.Types)
 local External = require(script.External)
 
+type Fusion = Types.Fusion
+
 export type Animatable = Types.Animatable
 export type UsedAs<T> = Types.UsedAs<T>
 export type Child = Types.Child
@@ -18,7 +20,7 @@ export type GraphObject = Types.GraphObject
 export type For<KO, VO> = Types.For<KO, VO>
 export type Observer = Types.Observer
 export type PropertyTable = Types.PropertyTable
-export type Scope<Constructors> = Types.Scope<Constructors>
+export type Scope<Constructors = Fusion> = Types.Scope<Constructors>
 export type ScopedObject = Types.ScopedObject
 export type SpecialKey = Types.SpecialKey
 export type Spring<T> = Types.Spring<T>
@@ -36,7 +38,7 @@ do
 	External.setExternalProvider(RobloxExternal)
 end
 
-local Fusion: Types.Fusion = table.freeze {
+local Fusion: Fusion = table.freeze {
 	-- General
 	version = {major = 0, minor = 3, isRelease = false},
 	Contextual = require(script.Utility.Contextual),


### PR DESCRIPTION
This changes the default generic `Constructors` type on the exported `Scope` type, so that not specifying a `Constructors` type will default to the `Fusion` type.

That's a lot of words to mean that this:

```Luau
scope: Fusion.Scope<typeof(Fusion)>
```

Is now identical to this:

```Luau
scope: Fusion.Scope
```