### PR TITLE
 Remove custom error message for Instance.new in New

### DIFF
--- a/src/Instances/New.luau
+++ b/src/Instances/New.luau
@@ -20,7 +20,7 @@ local function New(
 	scope: Types.Scope<unknown>,
 	className: string
 )
-	if (className :: any) == nil then
+	if className == nil then
 		local scope = (scope :: any) :: string
 		External.logError("scopeMissing", nil, "instances using New", "myScope:New \"" .. scope .. "\" { ... }")
 	end
@@ -31,10 +31,7 @@ local function New(
 	return function(
 		props: Types.PropertyTable
 	): Instance
-		local ok, instance = pcall(Instance.new, className)
-		if not ok then
-			External.logError("cannotCreateClass", nil, className)
-		end
+		local instance = Instance.new(className)
 
 		local classDefaults = defaultProps[className]
 		if classDefaults ~= nil then

--- a/src/Logging/messages.luau
+++ b/src/Logging/messages.luau
@@ -12,7 +12,6 @@ return {
 	cannotAssignProperty = "The class type '%s' has no assignable property '%s'.",
 	cannotConnectChange = "The %s class doesn't have a property called '%s'.",
 	cannotConnectEvent = "The %s class doesn't have an event called '%s'.",
-	cannotCreateClass = "Can't create a new instance of class '%s'.",
 	cannotDepend = "%s can't depend on %s.",
 	cleanupWasRenamed = "`Fusion.cleanup` was renamed to `Fusion.doCleanup`. This will be an error in future versions of Fusion.",
 	destroyedTwice = "`doCleanup()` was given something that it is already cleaning up. Unclear how to proceed.",


### PR DESCRIPTION
The default error message that roblox provides is quite clear, and wrapping it like this is unnessaray.
Heres the error that roblox provides:
`Unable to create an Instance of type "lol"`