### PR TITLE
Add more descriptive error to Observer

### DIFF
--- a/src/Graph/Observer.luau
+++ b/src/Graph/Observer.luau
@@ -20,6 +20,7 @@ local depend = require(Package.Graph.depend)
 local evaluate = require(Package.Graph.evaluate)
 -- Utility
 local nicknames = require(Package.Utility.nicknames)
+local xtypeof = require(Package.Utility.xtypeof)
 
 type Self = Types.Observer & {
 	_watchingGraph: Types.GraphObject?,
@@ -39,7 +40,11 @@ local function Observer(
 ): Types.Observer
 	local createdAt = os.clock()
 	if watching == nil then
-		External.logError("scopeMissing", nil, "Observers", "myScope:Observer(watching)")
+		if xtypeof(scope) == "state" then
+			External.logError("scopeMissing", nil, "Observers", "myScope:Observer(watching)")
+		else -- if it isn't a state then assume the scope was given correctly, but the watching value is missing
+			error("Value provided to Observer to watch was not a state.")
+		end
 	end
 
 	local self: Self = setmetatable(


### PR DESCRIPTION
Currently if you give a scope, but not a state to watch, the Observer errors out telling you that your scope is missing. This led me on a goose chase trying to figure out why it wasn't able to find my scope. Turned out it wasn't the scope, but the state that was missing. 
This change aims to just adjust the error message displayed in this edge case. I wasn't sure how best to log the error, feel free to adjust.