### PR TITLE
QOL To allow Springs to take functions directly

### DIFF
--- a/src/Animation/Spring.luau
+++ b/src/Animation/Spring.luau
@@ -22,6 +22,7 @@ local evaluate = require(Package.Graph.evaluate)
 -- State
 local castToState = require(Package.State.castToState)
 local peek = require(Package.State.peek)
+local Computed = require(Package.State.Computed)
 -- Animation
 local ExternalTime = require(Package.Animation.ExternalTime)
 local Stopwatch = require(Package.Animation.Stopwatch)
@@ -59,13 +60,17 @@ local METATABLE = table.freeze {__index = class}
 
 local function Spring<T>(
 	scope: Types.Scope<unknown>,
-	goal: Types.UsedAs<T>,
+	goal: Types.UsedAs<T> | (Types.Use, Types.Scope<unknown>) -> T,
 	speed: Types.UsedAs<number>?,
 	damping: Types.UsedAs<number>?
 ): Types.Spring<T>
 	local createdAt = os.clock()
 	if typeof(scope) ~= "table" or castToState(scope) ~= nil then
 		External.logError("scopeMissing", nil, "Springs", "myScope:Spring(goalState, speed, damping)")
+	end
+
+	if typeof(goal) == "function" then
+		goal = Computed(scope, goal)
 	end
 
 	local goalState = castToState(goal)


### PR DESCRIPTION
Removes the need to wrap functions in Computeds every time when making Springs. Makes code a bit easier to read and write.

```lua
local toggle = scope:Value(false)

local mySpring = scope:Spring(function(use)
    return if use(toggle) then 1 else 0
end)
```