### PR TITLE
Fix merge not overwriting values (again)

### DIFF
--- a/src/Utility/merge.luau
+++ b/src/Utility/merge.luau
@@ -21,7 +21,7 @@ local function merge(
 	else
 		for _, fromTable in fromTables do
 			for key, value in fromTable do
-				if into[key] == nil then
+				if overwrite or into[key] == nil then
 					into[key] = value
 				elseif not overwrite then
 					External.logError("mergeConflict", nil, tostring(key))


### PR DESCRIPTION
Looks like the change I made in #343 got reverted in e690edc (specifically c8a4b79d2a255a0ed092896bd06035bbf16b4dc5). I am not sure whether this was intentional or not.

This PR reintroduces that fix, allowing values to get overwritten when using `merge` and the `overwrite` parameter is set to `true`. This behavior makes more sense as it allows constructors to get overwritten when deriving scopes, whereas currently the values will silently not get overwritten.

```lua
local scope = Fusion:scoped { Button = NormalButton }
local specialScope = scope:deriveScope { Button = SpecialButton }
```