### PR TITLE
Ensured all Cookbook examples work (#384)

### DIFF
--- a/docs/examples/cookbook/animated-computed.md
+++ b/docs/examples/cookbook/animated-computed.md
@@ -12,6 +12,7 @@ local Players = game:GetService("Players")
 
 local Fusion = -- initialise Fusion here however you please!
 local scoped = Fusion.scoped
+local peek = Fusion.peek
 local Children = Fusion.Children
 
 local TWEEN_INFO = TweenInfo.new(

--- a/docs/examples/cookbook/button-component.md
+++ b/docs/examples/cookbook/button-component.md
@@ -4,7 +4,7 @@ clicking.
 
 This should be a generally useful template for assembling components of your
 own. For further ideas and best practices for building components, see
-[the Components tutorial](../../../tutorials/components/components).
+[the Components tutorial](../../tutorials/best-practices/components).
 
 
 -----
@@ -13,7 +13,7 @@ own. For further ideas and best practices for building components, see
 
 ```Lua linenums="1"
 local Fusion = -- initialise Fusion here however you please!
-local scoped = Fusion.scoped
+local peek = Fusion.peek
 local Children, OnEvent = Fusion.Children, Fusion.OnEvent
 type UsedAs<T> = Fusion.UsedAs<T>
 
@@ -73,9 +73,8 @@ local function Button(
 					if use(props.Disabled) then COLOUR_BG_DISABLED
 					elseif use(isHeldDown) then COLOUR_BG_HELD
 					elseif use(isHovering) then COLOUR_BG_HOVER
-					else return COLOUR_BG_REST
-				end
-			end), 
+					else COLOUR_BG_REST
+				end), 
 			BG_FADE_SPEED
 		),
 
@@ -111,11 +110,11 @@ local function Button(
 		end,
 
 		[Children] = {
-			New "UICorner" {
+			scope:New "UICorner" {
 				CornerRadius = ROUNDED_CORNERS
 			},
 
-			New "UIPadding" {
+			scope:New "UIPadding" {
 				PaddingTop = PADDING.Y,
 				PaddingBottom = PADDING.Y,
 				PaddingLeft = PADDING.X,
@@ -159,12 +158,12 @@ local function Button(
 
 The `scope` parameter specifies that the component depends on Fusion's methods.
 If you're not sure how to write type definitions for scopes,
-[the 'Scopes' section of the Components tutorial](../../../tutorials/components/components/#scopes)
+[the 'Scopes' section of the Components tutorial](../../tutorials/best-practices/components#scopes)
 goes into further detail.
 
 The property table is laid out with each property on a new line, so it's easy to
 scan the list and see what properties are available. Most are typed with
-[`UsedAs`](../../../api-reference/state/types/usedas), which allows the user to 
+[`UsedAs`](../../api-reference/state/types/usedas), which allows the user to 
 use state objects if they desire. They're also `?` (optional), which can reduce
 boilerplate when using the component. Not all properties have to be that way,
 but usually it's better to have the flexibility.

--- a/docs/examples/cookbook/fetch-data-from-server.md
+++ b/docs/examples/cookbook/fetch-data-from-server.md
@@ -14,6 +14,7 @@ This example assumes the presence of a Roblox-like `task` scheduler.
 ```Lua linenums="1"
 local Fusion = -- initialise Fusion here however you please!
 local scoped = Fusion.scoped
+local peek = Fusion.peek
 
 local function fetchUserBio(
 	userID: number
@@ -41,7 +42,7 @@ do
 			task.cancel(fetchInProgress)
 		end
 		fetchInProgress = task.spawn(function()
-			currentUserBio:set(fetchUserBio())
+			currentUserBio:set(fetchUserBio(userID))
 			fetchInProgress = nil
 		end)
 	end

--- a/docs/examples/cookbook/light-and-dark-theme.md
+++ b/docs/examples/cookbook/light-and-dark-theme.md
@@ -8,6 +8,7 @@ state objects.
 ```Lua linenums="1"
 local Fusion = --initialise Fusion here however you please!
 local scoped = Fusion.scoped
+local peek = Fusion.peek
 
 local Theme = {}
 

--- a/docs/examples/cookbook/loading-spinner.md
+++ b/docs/examples/cookbook/loading-spinner.md
@@ -7,6 +7,7 @@ APIs.
 
 ```Lua linenums="1"
 local RunService = game:GetService("RunService")
+local Players = game:GetService("Players")
 
 local Fusion = -- initialise Fusion here however you please!
 local scoped = Fusion.scoped
@@ -59,13 +60,18 @@ table.insert(scope,
 	end)
 )
 
-local spinner = scope:Spinner {
-	Layout = {
-		Position = UDim2.fromScale(0.5, 0.5),
-		AnchorPoint = Vector2.new(0.5, 0.5),
-		Size = UDim2.fromOffset(50, 50)
-	},
-	CurrentTime = currentTime
+local gui = scope:New "ScreenGui" {
+	Name = "SpinnerGui",
+	Parent = Players.LocalPlayer:WaitForChild("PlayerGui"),
+
+	[Children] = scope:Spinner {
+		Layout = {
+			Position = UDim2.fromScale(0.5, 0.5),
+			AnchorPoint = Vector2.new(0.5, 0.5),
+			Size = UDim2.fromOffset(50, 50)
+		},
+		CurrentTime = currentTime
+	}
 }
 ```
 
@@ -118,7 +124,7 @@ table.insert(scope,
 This can then be passed in as `CurrentTime` when the `Spinner` is created.
 
 ```Lua hl_lines="7"
-local spinner = scope:Spinner {
+scope:Spinner {
 	Layout = {
 		Position = UDim2.fromScale(0.5, 0.5),
 		AnchorPoint = Vector2.new(0.5, 0.5),


### PR DESCRIPTION
Related to issue  #384 
- Fixed broken links to tutorials or api reference
- Most examples only needed minor fixes (declaring peek, missing calls to scope: etc)
- The biggest changes were to drag and drop:
    - Unused code blocks were removed
    - todoItems declaration had to be moved after scope was declared to be able to create Values. Ordering in the explanation was edited to reflect this
    - Added different positions and background colors to the lists. (They used to overlap and weren't distinct)
    - allEntries used to be a scope:ForValues which wouldn't get created until peeked at. Since it doesn't change I opted for creating them using a normal for loop.