### PR TITLE
Fix for Value :set typing

### DIFF
--- a/src/State/Value.luau
+++ b/src/State/Value.luau
@@ -66,8 +66,8 @@ end
 
 function class.set<T, S>(
 	self: Self<T, S>,
-	newValue: S
-): S
+	newValue: T
+): T
 	local oldValue = self._EXTREMELY_DANGEROUS_usedAsValue
 	if not isSimilar(oldValue, newValue) then
 		self._EXTREMELY_DANGEROUS_usedAsValue = newValue :: any


### PR DESCRIPTION
When trying to set a type defined value it is tyrying to compare against the scope type rather than the defined stored value type. This just swaps out for the correct generic.

Is there some reason this was originally intended and Im just utilizing things incorrectly?