### PR TITLE
Developer documentation pipeline deployment fix

### DIFF
--- a/docs/examples/cookbook/drag-and-drop.md
+++ b/docs/examples/cookbook/drag-and-drop.md
@@ -178,9 +178,9 @@ local function TodoEntry(
 
 			[OnEvent "MouseButton1Down"] = props.OnMouseDown
 
-			-- Don't detect mouse up here, because in some rare cases, the event
-			-- could be missed due to lag between the item's position and the
-			-- cursor position.
+			--[[ Don't detect mouse up here, because in some rare cases, 
+			the event could be missed due to lag between the item's 
+			position and the cursor position.]]
 		}
 	}
 end
@@ -508,9 +508,9 @@ respond to mouse-up, even if the mouse happens to briefly leave this element.
 ```Lua
 			[OnEvent "MouseButton1Down"] = props.OnMouseDown
 
-			-- Don't detect mouse up here, because in some rare cases, the event
-			-- could be missed due to lag between the item's position and the
-			-- cursor position.
+			--[[ Don't detect mouse up here, because in some rare cases, 
+			the event could be missed due to lag between the item's 
+			position and the cursor position.]]
 ```
 
 The example creates a list of `TodoItem` objects, each with a unique ID, text


### PR DESCRIPTION
It seems that mkdocs for some reason hangs (or takes long enough to process for the difference to not matter) when it finds consecutive comments; file size and code block length must have something to do with it.

Also seems to not like multiline comments. When testing on my machine if I were to turn turn the changed comments into just one line I'd get a speed increase of almost 30% **for the whole deployment**.

Worth noting down somewhere for the future in contribution guidelines? Couldn't find any related issues on the internet