### PR TITLE
Fix invalid luau-lsp Aftman dependency

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -5,4 +5,4 @@
 [tools]
 rojo = "rojo-rbx/rojo@7.4.1"
 selene = "Kampfkarren/selene@0.26.1"
-luau-lsp = "JohnnyMorganz/luau-lsp@1.38.1"
+luau-lsp = "JohnnyMorganz/luau-lsp@1.57.1"


### PR DESCRIPTION
For whatever reason Aftman fails to install [luau-lsp](https://github.com/JohnnyMorganz/luau-lsp/releases) 1.28.1, [breaking CI](https://github.com/dphfox/Fusion/actions/runs/20015861032), updating to 1.57.1 fixes this.
(as a sidenote, having a quick guide on setting up and building the Fusion repo would be super helpful)