### PR TITLE
Fix `error.context` message in `ForPairs` (#396)

### DIFF
--- a/src/State/ForPairs.luau
+++ b/src/State/ForPairs.luau
@@ -64,7 +64,7 @@ local function SubObject<KI, KO, VI, VO, S>(
 			return {key = outputKey, value = outputValue}
 		else
 			local error: Types.Error = outputKey :: any
-			error.context = `while processing key {tostring(inputValue)} and value {tostring(inputValue)}`
+			error.context = `while processing key {tostring(inputKey)} and value {tostring(inputValue)}`
 			External.logErrorNonFatal("callbackError", error)
 			doCleanup(scope)
 			table.clear(scope)


### PR DESCRIPTION
Resolves #396

Corrects the error context string to reference the correct `inputKey` and `inputValue` when logging non-fatal callback errors.